### PR TITLE
GitHub Action to find undefined names in Python code

### DIFF
--- a/.github/workflows/undefined_names.yml
+++ b/.github/workflows/undefined_names.yml
@@ -1,0 +1,11 @@
+name: undefined_names
+on: [pull_request, push]
+jobs:
+  undefined_names:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip
+      - run: pip install flake8
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/openfold/data/mmcif_parsing.py
+++ b/openfold/data/mmcif_parsing.py
@@ -26,6 +26,7 @@ from Bio import PDB
 from Bio.Data import SCOPData
 import numpy as np
 
+from openfold.data.templates import MultipleChainsError
 import openfold.np.residue_constants as residue_constants
 
 

--- a/openfold/utils/feats.py
+++ b/openfold/utils/feats.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import numpy as np
+import tensorflow as tf
 import torch
 import torch.nn as nn
 from typing import Dict

--- a/openfold/utils/feats.py
+++ b/openfold/utils/feats.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn as nn
 from typing import Dict
 
+from openfold.np import protein
 import openfold.np.residue_constants as rc
 from openfold.utils.affine_utils import T
 from openfold.utils.tensor_utils import (

--- a/openfold/utils/feats.py
+++ b/openfold/utils/feats.py
@@ -16,7 +16,6 @@
 import math
 
 import numpy as np
-import tensorflow as tf
 import torch
 import torch.nn as nn
 from typing import Dict

--- a/openfold/utils/loss.py
+++ b/openfold/utils/loss.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from functools import partial
+import logging
 import ml_collections
 import numpy as np
 import torch


### PR DESCRIPTION
Test results: https://github.com/cclauss/openfold/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does  _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests focus on runtime safety and correctness:
* __E9__ tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* __F63__ tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* __F7__ tests logic errors and syntax errors in type hints
* __F82__ tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.