### PR TITLE
Add requirements for building docker container

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build . --file Dockerfile --tag openfold-image:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+FROM nvidia/cuda:11.3.0-cudnn8-runtime-ubuntu18.04
+
+RUN \
+    apt-get update && \
+    apt-get -y install wget \
+    aria2 \
+    rsync \
+    cmake \
+    build-essential \
+    curl \
+    git \
+    vim \
+    nvidia-cuda-toolkit
+
+# install miniconda
+RUN \
+    curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh && \
+    sh miniconda.sh -b -p /tools/miniconda && \
+    rm miniconda.sh && \
+    /tools/miniconda/bin/conda init && \
+    /tools/miniconda/bin/conda clean -a
+ENV PATH "$PATH:/tools/miniconda/bin"
+
+COPY . /openfold
+WORKDIR /openfold
+
+# Create environment
+RUN conda env create -f environment.yaml
+SHELL ["conda", "run", "-n", "openfold-env", "/bin/bash", "-c"]
+RUN pip install -r requirements.txt
+RUN pip install nvidia-pyindex \
+    && pip install nvidia-dllogger
+SHELL ["/bin/sh", "-c"]
+
+#clone mmseqs2 and compile
+WORKDIR /
+RUN git clone https://github.com/soedinglab/MMseqs2.git
+RUN mkdir -p /MMseqs2/build
+WORKDIR /MMseqs2/build
+RUN cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=. .. ; make ; make install
+WORKDIR /openfold
+
+# Download folding resources
+RUN mkdir -p resources
+RUN wget -q -P resources \
+    https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
+
+# Download pretrain alphafold weights
+RUN scripts/download_alphafold_params.sh /openfold/resources/
+
+# execute startup script
+RUN chmod +x /openfold/startup.sh
+ENTRYPOINT ["startup.sh"]

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,16 @@
+name: openfold-env
+channels:
+- conda-forge
+- bioconda
+- defaults
+dependencies:
+- python=3.7
+- pandas
+- pip
+- scikit-learn
+- biopython
+- openmm=7.5.1
+- pdbfixer
+- hmmer=3.3.2
+- hhsuite=3.3.0
+- kalign2=2.04

--- a/openfold/np/residue_constants.py
+++ b/openfold/np/residue_constants.py
@@ -452,7 +452,7 @@ def load_stereo_chemical_props() -> Tuple[
       residue_bond_angles: dict that maps resname --> list of BondAngle tuples
     """
     # TODO: this file should be downloaded in a setup script
-    stereo_chemical_props_path = "/openfold/resources/stereo_chemical_props.txt"
+    stereo_chemical_props_path = "openfold/resources/stereo_chemical_props.txt"
     with open(stereo_chemical_props_path, "rt") as f:
         stereo_chemical_props = f.read()
     lines_iter = iter(stereo_chemical_props.splitlines())

--- a/openfold/np/residue_constants.py
+++ b/openfold/np/residue_constants.py
@@ -452,7 +452,7 @@ def load_stereo_chemical_props() -> Tuple[
       residue_bond_angles: dict that maps resname --> list of BondAngle tuples
     """
     # TODO: this file should be downloaded in a setup script
-    stereo_chemical_props_path = "openfold/resources/stereo_chemical_props.txt"
+    stereo_chemical_props_path = "/openfold/resources/stereo_chemical_props.txt"
     with open(stereo_chemical_props_path, "rt") as f:
         stereo_chemical_props = f.read()
     lines_iter = iter(stereo_chemical_props.splitlines())

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Export mmseqs path
+export PATH=/MMseqs2/build/bin/:$PATH
+
+# Install DeepMind's OpenMM patch
+patch -p0 -d /tools/miniconda/envs/ottf-openfold/lib/python3.7/site-packages/ < /openfold/lib/openmm.patch
+
+# Activate environment
+source activate openfold-env
+
+# Install openfold
+python setup.py install


### PR DESCRIPTION
Minimum requirements for building a docker container for openfold and addition of github action to test that docker image can be built. There are two issues to be resolved:
1) Hosting of data required for training/inference. This docker image does not include downloading the data (sequence databases and structures) for training or running inference because these require a lot of storage. Guidance on the best way to attach this data would be appreciated! Personally, I have created a GCP persistent disk with these data that can be attached to an image running the container. 
2) Storage of the docker container in an open source space. The docker container can be built using the GitHub Action but it isn't stored anywhere (e.g. Docker hub). [Here are instructions for how to publish this container](https://github.com/marketplace/actions/publish-docker), but I would appreciate input from OpenFold maintainers about how they might want to publish the container!

I'm definitely not a Docker expert but I thought I'd try to contribute and get some feedback from others!