### PR TITLE
update loss logging and stop sampling recycling iterations in validation

### DIFF
--- a/openfold/config.py
+++ b/openfold/config.py
@@ -174,7 +174,6 @@ config = mlc.ConfigDict(
             },
             "supervised": {
                 "clamp_prob": 0.9,
-                "uniform_recycling": True,
                 "supervised_features": [
                     "all_atom_mask",
                     "all_atom_positions",
@@ -194,6 +193,7 @@ config = mlc.ConfigDict(
                 "crop_size": None,
                 "supervised": False,
                 "subsample_recycling": False,
+                "uniform_recycling": False,
             },
             "eval": {
                 "fixed_size": True,
@@ -206,6 +206,7 @@ config = mlc.ConfigDict(
                 "crop_size": None,
                 "supervised": True,
                 "subsample_recycling": False,
+                "uniform_recycling": False,
             },
             "train": {
                 "fixed_size": True,
@@ -221,6 +222,7 @@ config = mlc.ConfigDict(
                 "clamp_prob": 0.9,
                 "subsample_recycling": True,
                 "max_distillation_msa_clusters": 1000,
+                "uniform_recycling": True,
             },
             "data_module": {
                 "use_small_bfd": False,

--- a/openfold/data/data_modules.py
+++ b/openfold/data/data_modules.py
@@ -284,21 +284,19 @@ class OpenFoldDataLoader(torch.utils.data.DataLoader):
                 ("use_clamped_fape", [1 - clamp_prob, clamp_prob])
             )
 
-        if(self.stage == "train" and self.config.supervised.uniform_recycling):
+        if(stage_cfg.uniform_recycling):
             recycling_probs = [
                 1. / (max_iters + 1) for _ in range(max_iters + 1)
             ]
-            keyed_probs.append(
-                ("no_recycling_iters", recycling_probs)
-            )
         else:
             recycling_probs = [
                 0. for _ in range(max_iters + 1)
             ]
             recycling_probs[-1] = 1.
-            keyed_probs.append(
-                ("no_recycling_iters", recycling_probs)
-            )
+
+        keyed_probs.append(
+            ("no_recycling_iters", recycling_probs)
+        )
 
         keys, probs = zip(*keyed_probs)
         max_len = max([len(p) for p in probs])

--- a/openfold/data/data_modules.py
+++ b/openfold/data/data_modules.py
@@ -245,7 +245,7 @@ class OpenFoldDataset(torch.utils.data.IterableDataset):
 
 
 class OpenFoldBatchCollator:
-    def __init__(self, config, generator, stage="train"):
+    def __init__(self, config, stage="train"):
         self.stage = stage
         self.feature_pipeline = feature_pipeline.FeaturePipeline(config)
 
@@ -503,7 +503,7 @@ class OpenFoldDataModule(pl.LightningDataModule):
         else:
             raise ValueError("Invalid stage")
 
-        batch_collator = OpenFoldBatchCollator(self.config, generator, stage)
+        batch_collator = OpenFoldBatchCollator(self.config, stage)
 
         dl = OpenFoldDataLoader(
             dataset,

--- a/openfold/data/data_modules.py
+++ b/openfold/data/data_modules.py
@@ -283,13 +283,14 @@ class OpenFoldDataLoader(torch.utils.data.DataLoader):
             keyed_probs.append(
                 ("use_clamped_fape", [1 - clamp_prob, clamp_prob])
             )
-            if(self.config.supervised.uniform_recycling):
-                recycling_probs = [
-                    1. / (max_iters + 1) for _ in range(max_iters + 1)
-                ]
-                keyed_probs.append(
-                    ("no_recycling_iters", recycling_probs)
-                )
+
+        if(self.stage == "train" and self.config.supervised.uniform_recycling):
+            recycling_probs = [
+                1. / (max_iters + 1) for _ in range(max_iters + 1)
+            ]
+            keyed_probs.append(
+                ("no_recycling_iters", recycling_probs)
+            )
         else:
             recycling_probs = [
                 0. for _ in range(max_iters + 1)

--- a/openfold/data/data_modules.py
+++ b/openfold/data/data_modules.py
@@ -505,7 +505,7 @@ class OpenFoldDataModule(pl.LightningDataModule):
         else:
             raise ValueError("Invalid stage")
 
-        batch_collator = OpenFoldBatchCollator(self.config, stage)
+        batch_collator = OpenFoldBatchCollator(self.config, generator, stage)
 
         dl = OpenFoldDataLoader(
             dataset,

--- a/train_openfold.py
+++ b/train_openfold.py
@@ -66,7 +66,7 @@ class OpenFoldWrapper(pl.LightningModule):
 
         # Compute loss
         loss = self.loss(outputs, batch)
-
+        self.log("loss", loss)
         return {"loss": loss}
 
     def validation_step(self, batch, batch_idx):
@@ -79,6 +79,7 @@ class OpenFoldWrapper(pl.LightningModule):
         outputs = self(batch)
         batch = tensor_tree_map(lambda t: t[..., -1], batch)
         loss = self.loss(outputs, batch)
+        self.log("val_loss", loss, prog_bar=True)
         return {"val_loss": loss}
 
     def validation_epoch_end(self, _):


### PR DESCRIPTION
Fixes https://github.com/aqlaboratory/openfold/issues/56 
Fixes https://github.com/aqlaboratory/openfold/issues/51
Fixes OpenFoldBatchCollator: generator argument not properly set and stage ignored (defaulting to train) 

Edit: I just noticed that the generator argument is never used. Could be removed from OpenFoldBatchCollator