### PR TITLE
Fix parameter restorage after loading EMA parameters 

### DIFF
--- a/train_openfold.py
+++ b/train_openfold.py
@@ -125,7 +125,11 @@ class OpenFoldWrapper(pl.LightningModule):
     def validation_step(self, batch, batch_idx):
         # At the start of validation, load the EMA weights
         if(self.cached_weights is None):
-            self.cached_weights = self.model.state_dict()
+            # load_state_dict() is an in-place operation
+            # it will change the content in any reference of model.state_dict()
+            # therefore we need to explicitly clone the parameters
+            clone_param = lambda t: t.clone().detach()
+            self.cached_weights = tensor_tree_map(clone_param, self.model.state_dict())
             self.model.load_state_dict(self.ema.state_dict()["params"])
        
         # Run the model


### PR DESCRIPTION
This PR fixes a serious bug in training. The original code loads EMA parameters during validation, but fails to restore the training parameters after validation.

In [these lines](https://github.com/aqlaboratory/openfold/blob/main/train_openfold.py#L127-L129), `self.cached_weights = self.model.state_dict()` only keeps a reference to the parameters, rather than a copy. However, `self.model.load_state_dict()` performs an in-place update to the parameters, which unintentionally changes the parameters in `self.cached_weights`. Therefore, [the callback](https://github.com/aqlaboratory/openfold/blob/main/train_openfold.py#L143-L146) at the end of validation step fails to restore the correct parameters.

In other words, the current implementation always replaces the training parameters with EMA parameters at the end of each epoch. Empirically, I found this slows down the convergence very much.