### PR TITLE
fixing CUDA versions in dockerfile and a small bug in run_pretrained_openfold.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04
+FROM nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04
 
-RUN apt-get update && apt-get install -y wget cuda-minimal-build-11-0 git
+RUN apt-get update && apt-get install -y wget cuda-minimal-build-10-2 git
 RUN wget -P /tmp \
     "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" \
     && bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda \

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - conda-forge::pip
   - conda-forge::openmm=7.5.1
   - conda-forge::pdbfixer
+  - conda-forge::cudatoolkit==10.2.*
   - bioconda::hmmer==3.3.2
   - bioconda::hhsuite==3.3.0
   - bioconda::kalign2==2.04

--- a/run_pretrained_openfold.py
+++ b/run_pretrained_openfold.py
@@ -167,7 +167,7 @@ def main(args):
         
         # Relax the prediction.
         t = time.perf_counter()
-        visible_devices = os.getenv("CUDA_VISIBLE_DEVICES")
+        visible_devices = os.getenv("CUDA_VISIBLE_DEVICES", default="")
         if("cuda" in args.model_device):
             device_no = args.model_device.split(":")[-1]
             os.environ["CUDA_VISIBLE_DEVICES"] = device_no


### PR DESCRIPTION
This PR addresses two issues I ran into recently: 

1) pytorch 1.10 only supports cuda 10.2 or 11.3 as distributed in conda, but the version of openmm required (7.5) doesn't support 11.3, only 10.2, so in order for everything to work well we need to dockerfile to use cuda 10.2 not 11.1
2) if you dont have `CUDA_VISIBLE_DEVICES` in your environment but do specify the `--model_device` flag when runnint `run_pretrained_openfold.py` you get an error at the end of the script when `os.setenv` tries to cast a `None` into a string, a more sensible default for the missing environment variable is `""`