### PR TITLE
add correct GPG key to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04
 
+RUN apt-key del 7fa2af80
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update && apt-get install -y wget cuda-minimal-build-10-2 git
 RUN wget -P /tmp \
     "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" \


### PR DESCRIPTION
the nvidia GPG keys used for their apt repository changed and they havent pushed fixed versions of the docker containers yet. this PR manually adds the correct keys. 