### PR TITLE
Fix for issue in download_mgnify.sh

### DIFF
--- a/scripts/download_mgnify.sh
+++ b/scripts/download_mgnify.sh
@@ -38,6 +38,4 @@ BASENAME=$(basename "${SOURCE_URL}")
 
 mkdir --parents "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"
-pushd "${ROOT_DIR}"
 gunzip "${ROOT_DIR}/${BASENAME}"
-popd


### PR DESCRIPTION
While running `download_alphafold_dbs.sh`, the gunzip command in `download_mgnify.sh` failed for me. Due to a simple path problem.