### PR TITLE
Fix missing subtract_plddt argument in prep_output call

### DIFF
--- a/run_pretrained_openfold.py
+++ b/run_pretrained_openfold.py
@@ -266,7 +266,8 @@ def main(args):
                 feature_dict, 
                 feature_processor, 
                 args.config_preset,
-                args.multimer_ri_gap
+                args.multimer_ri_gap,
+                args.subtract_plddt
             )
 
             unrelaxed_output_path = os.path.join(


### PR DESCRIPTION
This PR is a very minor bug fix to add `args.subtract_plddt` to the `prep_output`call which otherwise fails due to a missing argument.

Interestingly `subtract_plddt` is already defined in the argument parser, but never used in the script.