### PR TITLE
Add link to model weights on Hugging Face

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ OpenFold is trainable in full precision or `bfloat16` with or without DeepSpeed,
 and we've trained it from scratch, matching the performance of the original. 
 We've publicly released model weights and our training data &mdash; some 400,000 
 MSAs and PDB70 template hit files &mdash; under a permissive license. Model weights 
-are available via scripts in this repository while the MSAs are hosted by the 
-[Registry of Open Data on AWS (RODA)](https://registry.opendata.aws/openfold). 
+are available via scripts in this repository or [on Hugging Face](https://huggingface.co/nz/OpenFold),
+while the MSAs are hosted by the [Registry of Open Data on AWS (RODA)](https://registry.opendata.aws/openfold). 
 Try out running inference for yourself with our [Colab notebook](https://colab.research.google.com/github/aqlaboratory/openfold/blob/main/notebooks/OpenFold.ipynb).
 
 OpenFold also supports inference using AlphaFold's official parameters, and 


### PR DESCRIPTION
Hello! I noticed a reference to weights on Hugging Face in the [weights-downloading script](https://github.com/aqlaboratory/openfold/blob/3de3bcb9a0c80ab73194201db65a662a036e2391/scripts/download_openfold_params_gdrive.sh#L18), so I tracked down the Hugging Face model repo and added a link to it in this repo's README.

It's the same one that [was used in the notebook at some point](https://github.com/aqlaboratory/openfold/commit/42a89f8cbe819a112a1a7f170bcae11bb4c9adf2). Let me know if there's actually a different one that should be used, or if you have a different preference on how to link the weights here!

cc: @osanseviero