### PR TITLE
fp16 fixes 

### DIFF
--- a/openfold/model/outer_product_mean.py
+++ b/openfold/model/outer_product_mean.py
@@ -93,7 +93,7 @@ class OuterProductMean(nn.Module):
 
         return outer
 
-    def forward(self, 
+    def _forward(self, 
         m: torch.Tensor, 
         mask: Optional[torch.Tensor] = None,
         chunk_size: Optional[int] = None,
@@ -143,3 +143,18 @@ class OuterProductMean(nn.Module):
             outer = outer / norm
 
         return outer
+
+    def forward(self,
+                m: torch.Tensor,
+                mask: Optional[torch.Tensor] = None,
+                chunk_size: Optional[int] = None,
+                inplace_safe: bool = False,
+    ) -> torch.Tensor:
+
+        float16_enabled = (torch.get_autocast_gpu_dtype() == torch.float16)
+        if float16_enabled and torch.is_autocast_enabled():
+            with torch.cuda.amp.autocast(enabled=False):
+                return self._forward(m.float(), mask, chunk_size, inplace_safe)
+        else:
+            return self._forward(m, mask, chunk_size, inplace_safe)
+        

--- a/openfold/model/primitives.py
+++ b/openfold/model/primitives.py
@@ -479,7 +479,9 @@ class Attention(nn.Module):
         q, k, v = self._prep_qkv(q_x, kv_x)
 
         # [*, Q, H, C_hidden]
-        use_memory_efficient_kernel = False
+        float16_enabled = (torch.get_autocast_gpu_dtype() == torch.float16)
+        if float16_enabled:
+            use_memory_efficient_kernel = False
         if(use_memory_efficient_kernel):
             if(len(biases) > 2):
                 raise ValueError(

--- a/openfold/model/primitives.py
+++ b/openfold/model/primitives.py
@@ -479,6 +479,7 @@ class Attention(nn.Module):
         q, k, v = self._prep_qkv(q_x, kv_x)
 
         # [*, Q, H, C_hidden]
+        use_memory_efficient_kernel = False
         if(use_memory_efficient_kernel):
             if(len(biases) > 2):
                 raise ValueError(

--- a/openfold/model/triangular_multiplicative_update.py
+++ b/openfold/model/triangular_multiplicative_update.py
@@ -391,7 +391,12 @@ class TriangleMultiplicativeUpdate(nn.Module):
         b = mask
         b = b * self.sigmoid(self.linear_b_g(z))
         b = b * self.linear_b_p(z)
-        x = self._combine_projections(a, b)
+        float16_enabled = (torch.get_autocast_gpu_dtype() == torch.float16)
+        if float16_enabled and torch.is_autocast_enabled():
+            with torch.cuda.amp.autocast(enabled=False):
+                x = self._combine_projections(a.float(), b.float())
+        else:
+            x = self._combine_projections(a, b)
         del a, b
         x = self.layer_norm_out(x)
         x = self.linear_z(x)


### PR DESCRIPTION
In AMP fp16 mode, overflow issues were observed in several places in the network.  To address this, those regions are now converted back to fp32. This change does not introduce significant performance cost which offsets the benefits of mixed precision training. We also disallow the use of memory efficient kernel (use_memory_efficient_kernel=false) in AMP fp16 mode explicitly. 

It worth mentioning the debugging tool developed at huggingface for detecting overflow issue: https://huggingface.co/docs/transformers/v4.14.1/en/debugging