### PR TITLE
Set clamped vs unclamped FAPE for each sample in batch independently

### DIFF
--- a/openfold/data/data_modules.py
+++ b/openfold/data/data_modules.py
@@ -440,11 +440,6 @@ class OpenFoldDataLoader(torch.utils.data.DataLoader):
         stage_cfg = self.config[self.stage]
 
         max_iters = self.config.common.max_recycling_iters
-        if(stage_cfg.supervised):
-            clamp_prob = self.config.supervised.clamp_prob
-            keyed_probs.append(
-                ("use_clamped_fape", [1 - clamp_prob, clamp_prob])
-            )
         
         if(stage_cfg.uniform_recycling):
             recycling_probs = [

--- a/openfold/data/feature_pipeline.py
+++ b/openfold/data/feature_pipeline.py
@@ -94,6 +94,21 @@ def np_example_to_features(
             cfg[mode],
         )
 
+    if mode == "train":
+        p = torch.rand(1).item()
+        use_clamped_fape_value = float(p < cfg.supervised.clamp_prob)
+        features["use_clamped_fape"] = torch.full(
+            size=[cfg.common.max_recycling_iters + 1],
+            fill_value=use_clamped_fape_value,
+            dtype=torch.float32,
+        )
+    else:
+        features["use_clamped_fape"] = torch.full(
+            size=[cfg.common.max_recycling_iters + 1],
+            fill_value=0.0,
+            dtype=torch.float32,
+        )
+
     return {k: v for k, v in features.items()}
 
 


### PR DESCRIPTION
Previously, whether to use clamped vs unclamped FAPE backbone loss was decided once for all samples in the mini-batch.

Now, clamped vs unclamped FAPE backbone loss is decided for each sample in the mini-batch independently. This brings substantial improvements to training convergence and stability.