### PR TITLE
Small fix for prep_mmseqs_dbs.

### DIFF
--- a/scripts/prep_mmseqs_dbs.sh
+++ b/scripts/prep_mmseqs_dbs.sh
@@ -23,7 +23,7 @@ DOWNLOAD_DIR="$1"
 ROOT_DIR="${DOWNLOAD_DIR}/mmseqs_dbs"
 mkdir -p $ROOT_DIR
 
-for f in $(ls ${DOWNLOAD_DIR}/*.tar.gz)
+for f in $(ls ${DOWNLOAD_DIR}/*.tar*)
 do
   tar --extract --verbose --file="${f}" \
       --directory=$ROOT_DIR


### PR DESCRIPTION
Hello!

I ran into an issue when following the README instructions.

Because `download_mm_seqs_dbs.sh` downloads and unzips its target file (`uniref30_2103.tar.gz`) instead of leaving it as `.tar.gz`, `prep_mmseqs_dbs.sh` mistakenly does not process this file. At least, I guess that this is not intended behavior. This commit expands the glob used in the script to match \*.tar\* files and thus process `uniref30_2103.tar` correctly.

This commit is somewhat in response to #202.