### PR TITLE
Obsolete parsing and File not found fix

### DIFF
--- a/openfold/data/templates.py
+++ b/openfold/data/templates.py
@@ -130,6 +130,22 @@ def _is_after_cutoff(
         return False
 
 
+def _replace_obsolete_references(obsolete_mapping) -> Mapping[str, str]:
+    """Generates a new obsolete by tracing all cross-references and store the latest leaf to all referencing nodes"""
+    obsolete_new = {}
+    obsolete_keys = obsolete_mapping.keys()
+
+    def _new_target(k):
+        v = obsolete_mapping[k]
+        if v in obsolete_keys:
+            return _new_target(v)
+        return v
+    
+    for k in obsolete_keys:
+        obsolete_new[k] = _new_target(k)
+
+    return obsolete_new
+
 def _parse_obsolete(obsolete_file_path: str) -> Mapping[str, str]:
     """Parses the data file from PDB that lists which PDB ids are obsolete."""
     with open(obsolete_file_path) as f:
@@ -143,6 +159,7 @@ def _parse_obsolete(obsolete_file_path: str) -> Mapping[str, str]:
                 from_id = line[20:24].lower()
                 to_id = line[29:33].lower()
                 result[from_id] = to_id
+        _replace_obsolete_references(result)
         return result
 
 

--- a/openfold/data/templates.py
+++ b/openfold/data/templates.py
@@ -159,8 +159,7 @@ def _parse_obsolete(obsolete_file_path: str) -> Mapping[str, str]:
                 from_id = line[20:24].lower()
                 to_id = line[29:33].lower()
                 result[from_id] = to_id
-        _replace_obsolete_references(result)
-        return result
+        return _replace_obsolete_references(result)
 
 
 def generate_release_dates_cache(mmcif_dir: str, out_path: str):


### PR DESCRIPTION
Fix for #4 
The problem is that the obsolete.dat is parsed, but old references are not replaced by newer ones.
I pulled the obsolete last week and still got 'file not found' errors. I could trace it back to the file itself. I added code after parsing, which replaces all cross-references with the latest pdb-ids, replacing all older ones. An example can be shown in the following table:

  | <       |     OLD    |        |   >     | \|  |         <   |     NEW    |        |    >  | 
  |   ---   |     ---    |  ---   |  ---    | --- |     ---     |    ---     |  ---   |  ---  |
  | OBSLTE  |  13-MAY-20 | 6L2V   |  7BYZ   | \|  |     OBSLTE  |  13-MAY-20 | 6L2V   |  7DE5 |
  | OBSLTE  |  22-JUL-20 | 7BYZ   |  7CH2   | \|  |     OBSLTE  |  22-JUL-20 | 7BYZ   |  7DE5 |
  | OBSLTE  |  25-NOV-20 | 7CH2   |  7DE5   | \|  |     OBSLTE  |  25-NOV-20 | 7CH2   |  7DE5 |

If you had 6L2V as input, it currently searches for 7BYZ and throws an error and stops.
In the new version, 6L2V gets replaced with 7DE5 and it works flawlessly.