### PR TITLE
Resolving torch cuda availability for cpu-only installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ import os
 from setuptools import setup, Extension, find_packages
 import subprocess
 
+import torch
 from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension, CUDA_HOME
 
 from scripts.utils import get_nvidia_cc
@@ -37,7 +38,7 @@ extra_cuda_flags = [
 ]
 
 def get_cuda_bare_metal_version(cuda_dir):
-    if cuda_dir==None:
+    if cuda_dir==None or torch.version.cuda==None:
         print("CUDA is not found, cpu version is installed")
         return None, -1, 0
     else:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# Originally from Openfold https://github.com/aqlaboratory/openfold, modified.
 # Copyright 2021 AlQuraishi Laboratory
 # Copyright 2021 DeepMind Technologies Limited
 #


### PR DESCRIPTION
Dear OpenFold developers,

We encountered a `TypeError: expected string or bytes-like object` error in `setup.py, line 111` when running pip install on a cpu-only machine. The current `setup.py` resolves CPU/GPU environments based on CUDA_HOME, but for cpu installations of pytorch (v1.13.1) this variable is set to `'/usr/local/cuda'` by default. This caused pip install to proceed to compiling the cuda kernels.

Here is a hotfix that ensures installing the cpu version when no cuda build of pytorch is detected.