### PR TITLE
Fix `--cpus_per_task` argument in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ python3 scripts/precompute_alignments.py mmcif_dir/ alignment_dir/ \
     --pdb70_database_path data/pdb70/pdb70 \
     --uniclust30_database_path data/uniclust30/uniclust30_2018_08/uniclust30_2018_08 \
     --bfd_database_path data/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt \
-    --cpus 16 \
+    --cpus_per_task 16 \
     --jackhmmer_binary_path lib/conda/envs/openfold_venv/bin/jackhmmer \
     --hhblits_binary_path lib/conda/envs/openfold_venv/bin/hhblits \
     --hhsearch_binary_path lib/conda/envs/openfold_venv/bin/hhsearch \


### PR DESCRIPTION
In the README, the instructions show `--cpus` being passed as a script argument to `precompute_alignments.py`, but the argument is actually named `--cpus_per_task`. 