### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.vscode/
+__pycache__/
+*.egg-info
+build
+dist
+
+# files from script downloads
+data
+openfold/resources/
+tests/test_data/


### PR DESCRIPTION
Adds a simple gitignore file with a few exclusions for auto-generated files and script download folders listed in the Readme.
This improves the development workflow for contributors and prevents accidentally checking in large folders into a branch. 