### PR TITLE
New option to output in ModelCIF format instead of PDB format

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,4 +27,5 @@ dependencies:
       - typing-extensions==3.10.0.2
       - pytorch_lightning==1.5.10
       - wandb==0.12.21
+      - modelcif==0.7
       - git+https://github.com/NVIDIA/dllogger.git

--- a/openfold/np/protein.py
+++ b/openfold/np/protein.py
@@ -503,8 +503,7 @@ def to_modelcif(prot: Protein) -> str:
 
     fh = io.StringIO()
     modelcif.dumper.write(fh, [system])
-    modelcifstr = fh.getvalue()
-    return modelcifstr
+    return fh.getvalue()
 
 
 def ideal_atom_mask(prot: Protein) -> np.ndarray:

--- a/openfold/np/protein.py
+++ b/openfold/np/protein.py
@@ -457,7 +457,7 @@ def to_modelcif(prot: Protein) -> str:
         asym_unit_map[chain_idx] = asym
     modeled_assembly = modelcif.Assembly(asym_unit_map.values(), name='Modeled assembly')
 
-    class MyModel(modelcif.model.HomologyModel):
+    class MyModel(modelcif.model.AbInitioModel):
         def get_atoms(self):
             # Add all atom sites.
             for i in range(n):

--- a/openfold/np/protein.py
+++ b/openfold/np/protein.py
@@ -82,8 +82,7 @@ def from_pdb_string(pdb_str: str, chain_id: Optional[str] = None) -> Protein:
 
     Args:
       pdb_str: The contents of the pdb file
-      chain_id: If None, then the pdb file must contain a single chain (which
-        will be parsed). If chain_id is specified (e.g. A), then only that chain
+      chain_id: If None, then the whole pdb file is parsed. If chain_id is specified (e.g. A), then only that chain
         is parsed.
 
     Returns:

--- a/openfold/np/protein.py
+++ b/openfold/np/protein.py
@@ -501,10 +501,6 @@ def to_modelcif(prot: Protein) -> str:
     model_group = modelcif.model.ModelGroup([model], name='All models')
     system.model_groups.append(model_group)
 
-    protocol = modelcif.protocol.Protocol()
-    # protocol.steps.append(modelcif.protocol.ModelingStep(
-    #     input_data=aln, output_data=model))
-    system.protocols.append(protocol)
     fh = io.StringIO()
     modelcif.dumper.write(fh, [system])
     modelcifstr = fh.getvalue()
@@ -567,7 +563,7 @@ def from_prediction(
 if __name__ == "__main__":
     pdb_file = '/home/jose/Downloads/171l.pdb'
     # pdb_file = '/home/jose/Downloads/2trx.pdb'
-    cif_file = '/home/jose/test1.cif'
+    cif_file = '/home/jose/test2.cif'
 
     with open(pdb_file, 'r') as file:
         pdbstr = file.read()

--- a/openfold/np/protein.py
+++ b/openfold/np/protein.py
@@ -571,19 +571,3 @@ def from_prediction(
         parents=parents,
         parents_chain_index=parents_chain_index,
     )
-
-
-if __name__ == "__main__":
-    # pdb_file = '/Users/jose/Downloads/171l.pdb'
-    # pdb_file = '/home/jose/Downloads/2trx.pdb'
-    pdb_file = '/Users/jose/Downloads/1bwd.pdb'
-    cif_file = '/Users/jose/test2.cif'
-
-    with open(pdb_file, 'r') as file:
-        pdbstr = file.read()
-
-    prot = from_pdb_string(pdbstr)
-    cifstr = to_modelcif(prot)
-    print(cifstr)
-    with open(cif_file, 'w') as fw:
-        fw.write(cifstr)

--- a/openfold/np/relax/amber_minimize.py
+++ b/openfold/np/relax/amber_minimize.py
@@ -524,9 +524,6 @@ def run_pipeline(
     _check_residues_are_well_defined(prot)
     pdb_string = clean_protein(prot, checks=checks)
 
-    # We keep the input around to restore metadata deleted by the relaxer
-    input_prot = prot
-
     exclude_residues = exclude_residues or []
     exclude_residues = set(exclude_residues)
     violations = np.inf

--- a/openfold/np/relax/relax.py
+++ b/openfold/np/relax/relax.py
@@ -78,8 +78,6 @@ class AmberRelaxation(object):
             "attempts": out["min_attempts"],
             "rmsd": rmsd,
         }
-        # TODO write all this as ModelCIF if param is true. Should be simply proteint.to_modelcif(prot)
-        #  and then add the other pieces, except that clean_protein() does quite some additional stuff...
         pdb_str = amber_minimize.clean_protein(prot)
         min_pdb = utils.overwrite_pdb_coordinates(pdb_str, min_pos)
         min_pdb = utils.overwrite_b_factors(min_pdb, prot.b_factors)
@@ -91,5 +89,11 @@ class AmberRelaxation(object):
         ]
 
         min_pdb = protein.add_pdb_headers(prot, min_pdb)
+        output_str = min_pdb
+        if cif_output:
+            # TODO the model cif will be missing some metadata like headers (PARENTs and
+            #      REMARK with some details of the run, like num of recycles)
+            final_prot = protein.from_pdb_string(min_pdb)
+            output_str = protein.to_modelcif(final_prot)
 
-        return min_pdb, debug_data, violations
+        return output_str, debug_data, violations

--- a/openfold/np/relax/relax.py
+++ b/openfold/np/relax/relax.py
@@ -57,7 +57,7 @@ class AmberRelaxation(object):
         self._use_gpu = use_gpu
 
     def process(
-        self, *, prot: protein.Protein
+        self, *, prot: protein.Protein, cif_output: bool
     ) -> Tuple[str, Dict[str, Any], np.ndarray]:
         """Runs Amber relax on a prediction, adds hydrogens, returns PDB string."""
         out = amber_minimize.run_pipeline(
@@ -78,6 +78,8 @@ class AmberRelaxation(object):
             "attempts": out["min_attempts"],
             "rmsd": rmsd,
         }
+        # TODO write all this as ModelCIF if param is true. Should be simply proteint.to_modelcif(prot)
+        #  and then add the other pieces, except that clean_protein() does quite some additional stuff...
         pdb_str = amber_minimize.clean_protein(prot)
         min_pdb = utils.overwrite_pdb_coordinates(pdb_str, min_pos)
         min_pdb = utils.overwrite_b_factors(min_pdb, prot.b_factors)

--- a/run_pretrained_openfold.py
+++ b/run_pretrained_openfold.py
@@ -288,7 +288,7 @@ def main(args):
             if not args.skip_relaxation:
                 # Relax the prediction.
                 logger.info(f"Running relaxation on {unrelaxed_output_path}...")
-                relax_protein(config, args.model_device, unrelaxed_protein, output_directory, output_name)
+                relax_protein(config, args.model_device, unrelaxed_protein, output_directory, output_name, args.cif_output)
 
             if args.save_outputs:
                 output_dict_path = os.path.join(

--- a/run_pretrained_openfold.py
+++ b/run_pretrained_openfold.py
@@ -1,6 +1,6 @@
 # Copyright 2021 AlQuraishi Laboratory
 # Copyright 2021 DeepMind Technologies Limited
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -35,7 +35,7 @@ torch_versions = torch.__version__.split(".")
 torch_major_version = int(torch_versions[0])
 torch_minor_version = int(torch_versions[1])
 if(
-    torch_major_version > 1 or 
+    torch_major_version > 1 or
     (torch_major_version == 1 and torch_minor_version >= 12)
 ):
     # Gives a large speedup on Ampere-class GPUs
@@ -70,7 +70,7 @@ def precompute_alignments(tags, seqs, alignment_dir, args):
         local_alignment_dir = os.path.join(alignment_dir, tag)
         if(args.use_precomputed_alignments is None and not os.path.isdir(local_alignment_dir)):
             logger.info(f"Generating alignments for {tag}...")
-                
+
             os.makedirs(local_alignment_dir)
 
             alignment_runner = data_pipeline.AlignmentRunner(
@@ -141,13 +141,13 @@ def main(args):
     os.makedirs(args.output_dir, exist_ok=True)
 
     config = model_config(args.config_preset, long_sequence_inference=args.long_sequence_inference)
-    
+
     if(args.trace_model):
         if(not config.data.predict.fixed_size):
             raise ValueError(
                 "Tracing requires that fixed_size mode be enabled in the config"
             )
-    
+
     template_featurizer = templates.TemplateHitFeaturizer(
         mmcif_dir=args.template_mmcif_dir,
         max_template_date=args.max_template_date,
@@ -165,10 +165,10 @@ def main(args):
     random_seed = args.data_random_seed
     if random_seed is None:
         random_seed = random.randrange(2**32)
-    
+
     np.random.seed(random_seed)
     torch.manual_seed(random_seed + 1)
-    
+
     feature_processor = feature_pipeline.FeaturePipeline(config.data)
     if not os.path.exists(output_dir_base):
         os.makedirs(output_dir_base)
@@ -183,7 +183,7 @@ def main(args):
         # Gather input sequences
         with open(os.path.join(args.fasta_dir, fasta_file), "r") as fp:
             data = fp.read()
-    
+
         tags, seqs = parse_fasta(data)
         # assert len(tags) == len(set(tags)), "All FASTA tags must be unique"
         tag = '-'.join(tags)
@@ -206,10 +206,10 @@ def main(args):
             output_name = f'{tag}_{args.config_preset}'
             if args.output_postfix is not None:
                 output_name = f'{output_name}_{args.output_postfix}'
-    
+
             # Does nothing if the alignments have already been computed
             precompute_alignments(tags, seqs, alignment_dir, args)
-        
+
             feature_dict = feature_dicts.get(tag, None)
             if(feature_dict is None):
                 feature_dict = generate_feature_dict(
@@ -234,7 +234,7 @@ def main(args):
             )
 
             processed_feature_dict = {
-                k:torch.as_tensor(v, device=args.model_device) 
+                k:torch.as_tensor(v, device=args.model_device)
                 for k,v in processed_feature_dict.items()
             }
 
@@ -255,30 +255,36 @@ def main(args):
 
             # Toss out the recycling dimensions --- we don't need them anymore
             processed_feature_dict = tensor_tree_map(
-                lambda x: np.array(x[..., -1].cpu()), 
+                lambda x: np.array(x[..., -1].cpu()),
                 processed_feature_dict
             )
             out = tensor_tree_map(lambda x: np.array(x.cpu()), out)
 
             unrelaxed_protein = prep_output(
-                out, 
-                processed_feature_dict, 
-                feature_dict, 
-                feature_processor, 
+                out,
+                processed_feature_dict,
+                feature_dict,
+                feature_processor,
                 args.config_preset,
                 args.multimer_ri_gap,
                 args.subtract_plddt
             )
 
+            unrelaxed_file_suffix = "_unrelaxed.pdb"
+            if args.cif_output:
+                unrelaxed_file_suffix = "_unrelaxed.cif"
             unrelaxed_output_path = os.path.join(
-                output_directory, f'{output_name}_unrelaxed.pdb'
+                output_directory, f'{output_name}{unrelaxed_file_suffix}'
             )
 
             with open(unrelaxed_output_path, 'w') as fp:
-                fp.write(protein.to_pdb(unrelaxed_protein))
+                if args.cif_output:
+                    fp.write(protein.to_modelcif(unrelaxed_protein))
+                else:
+                    fp.write(protein.to_pdb(unrelaxed_protein))
 
             logger.info(f"Output written to {unrelaxed_output_path}...")
-            
+
             if not args.skip_relaxation:
                 # Relax the prediction.
                 logger.info(f"Running relaxation on {unrelaxed_output_path}...")
@@ -373,12 +379,16 @@ if __name__ == "__main__":
         "--long_sequence_inference", action="store_true", default=False,
         help="""enable options to reduce memory usage at the cost of speed, helps longer sequences fit into GPU memory, see the README for details"""
     )
+    parser.add_argument(
+        "--cif_output", action="store_true", default=False,
+        help="Output predicted models in ModelCIF format instead of PDB format (default)"
+    )
     add_data_args(parser)
     args = parser.parse_args()
 
     if(args.jax_param_path is None and args.openfold_checkpoint_path is None):
         args.jax_param_path = os.path.join(
-            "openfold", "resources", "params", 
+            "openfold", "resources", "params",
             "params_" + args.config_preset + ".npz"
         )
 

--- a/thread_sequence.py
+++ b/thread_sequence.py
@@ -106,7 +106,7 @@ def main(args):
         logger.info(f"Output written to {unrelaxed_output_path}...")
 
         logger.info(f"Running relaxation on {unrelaxed_output_path}...")
-        relax_protein(config, args.model_device, unrelaxed_protein, output_directory, output_name)
+        relax_protein(config, args.model_device, unrelaxed_protein, output_directory, output_name, False)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
This should solve #284 . The one missing feature is headers (REMARK and PARENT). Which at this point I'm not sure how they would translate in ModelCIF.

As commented in #284, this also fixes a mistake in the docs for `protein.from_pdb_string()`