### PR TITLE
Add missing warmup_num_steps parameters to DeepSpeed config generation script.

### DIFF
--- a/scripts/build_deepspeed_config.py
+++ b/scripts/build_deepspeed_config.py
@@ -248,9 +248,10 @@ if(args.scheduler is not None):
         params["warmup_max_lr"] = args.warmup_max_lr
         params["warmup_num_steps"] = args.warmup_num_steps
     elif(args.scheduler == "WarmupDecayLR"):
-        params["total_num_steps"] = args.warmup_decay_total_num_steps
         params["warmup_min_lr"] = args.warmup_decay_min_lr
         params["warmup_max_lr"] = args.warmup_decay_max_lr
+        params["warmup_num_steps"] = args.warmup_decay_num_steps
+        params["total_num_steps"] = args.warmup_decay_total_num_steps
     else:
         raise ValueError("Invalid scheduler")
 


### PR DESCRIPTION
`warmup_decay_num_steps` and `warmup_decay_total_num_steps` are valid user arguments but are not added to the config. This commit adds both arguments to the configuration output.