### PR TITLE
Fix comparison for max_seqlen when downloading CAMEO.

### DIFF
--- a/scripts/download_cameo.py
+++ b/scripts/download_cameo.py
@@ -57,9 +57,8 @@ def main(args):
 
         seq = mmcif_object.chain_to_seqres[chain_id]
 
-        if(args.max_seqlen > 0):
-            if(len(seq) > len(seq)):
-                continue
+        if(args.max_seqlen > 0 and len(seq) > args.max_seqlen):
+            continue
 
         fasta_file = '\n'.join([
             f">{pdb_id}_{chain_id}",


### PR DESCRIPTION
Long sequences were previously not excluded during download. This commit changes the comparison to exclude sequences with length greater than `args.max_seqlen`. It also collapses a nested if-statement.