### PR TITLE
Improve TriangularMultiplicativeUpdate stability in fp16 mode

### DIFF
--- a/openfold/model/triangular_multiplicative_update.py
+++ b/openfold/model/triangular_multiplicative_update.py
@@ -392,8 +392,13 @@ class TriangleMultiplicativeUpdate(nn.Module):
         b = mask
         b = b * self.sigmoid(self.linear_b_g(z))
         b = b * self.linear_b_p(z)
-        
-        if(is_fp16_enabled()): 
+
+        # Prevents overflow of torch.matmul in combine projections in
+        # reduced-precision modes
+        a = a / a.std()
+	b = b / b.std()
+
+        if(is_fp16_enabled()):
             with torch.cuda.amp.autocast(enabled=False):
                 x = self._combine_projections(a.float(), b.float())
         else:


### PR DESCRIPTION
The solution to (observed) fp16 overflow in TriangularMultiplicativeUpdate torch.matmul caused by hugh std of a*b elements. It produces the same output as it's followed by layer norm which performs equivalent std-normalization.

`autocast=False` mode doesn't seem to solve this in pure fp16 mode unfortunately.

by @adamlerer 