### PR TITLE
Advance python version to 3.9 to build docker in Ubuntu Lunar Lobster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ COPY setup.py /opt/openfold/setup.py
 COPY lib/openmm.patch /opt/openfold/lib/openmm.patch
 RUN wget -q -P /opt/openfold/openfold/resources \
     https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
-RUN patch -p0 -d /opt/conda/lib/python3.7/site-packages/ < /opt/openfold/lib/openmm.patch
+RUN patch -p0 -d /opt/conda/lib/python3.9/site-packages/ < /opt/openfold/lib/openmm.patch
 WORKDIR /opt/openfold
 RUN python3 setup.py install

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - pytorch
 dependencies:
-  - conda-forge::python=3.7
+  - conda-forge::python=3.9
   - conda-forge::setuptools=59.5.0
   - conda-forge::pip
   - conda-forge::openmm=7.5.1

--- a/scripts/install_third_party_dependencies.sh
+++ b/scripts/install_third_party_dependencies.sh
@@ -27,7 +27,7 @@ cd $CUR_DIR
 
 # Install DeepMind's OpenMM patch
 OPENFOLD_DIR=$PWD
-pushd lib/conda/envs/$ENV_NAME/lib/python3.7/site-packages/ \
+pushd lib/conda/envs/$ENV_NAME/lib/python3.9/site-packages/ \
     && patch -p0 < $OPENFOLD_DIR/lib/openmm.patch \
     && popd
 

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 3.7,'
+        'Programming Language :: Python :: 3.9,'
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
     ],
 )


### PR DESCRIPTION
Advance python version from 3.7 to 3.9 at multiple places in the code. This fixes the docker build with Ubuntu Lunar Lobster which became "Latest" a few days ago.

(I noticed a likely broken docker build from main in my other PR #308. See it for more detailed comments.)
