### PR TITLE
Fix Colab third party packages install

### DIFF
--- a/notebooks/OpenFold.ipynb
+++ b/notebooks/OpenFold.ipynb
@@ -1,21 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "OpenFold.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -57,10 +40,32 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "#@title Install conda on Colab\n",
+        "#@markdown Please execute this cell by pressing the *Play* button on \n",
+        "#@markdown the left.\n",
+        "\n",
+        "\n",
+        "#@markdown **Note**: This cell will restart the kernel. \n",
+        "#@markdown make sure you run it first!\n",
+        "\n",
+        "\n",
+        "!pip install -q condacolab\n",
+        "import condacolab\n",
+        "condacolab.install_mambaforge()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "rowN0bVYLe9n",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "rowN0bVYLe9n"
       },
+      "outputs": [],
       "source": [
         "#@markdown ### Enter the amino acid sequence to fold ⬇️\n",
         "sequence = 'MAAHKGAEHHHKAAEHHEQAAKHHHAAAEHHEKGEHEQAAHHADTAYAHHKHAEEHAAQAAKHDAEHHAPKPH'  #@param {type:\"string\"}\n",
@@ -78,16 +83,16 @@
         "\n",
         "#@markdown After making your selections, execute this cell by pressing the\n",
         "#@markdown *Play* button on the left."
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "woIxeCPygt7K",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "woIxeCPygt7K"
       },
+      "outputs": [],
       "source": [
         "#@title Install third-party software\n",
         "#@markdown Please execute this cell by pressing the *Play* button on \n",
@@ -114,18 +119,8 @@
         "    # Install py3dmol.\n",
         "    %shell pip install py3dmol\n",
         "\n",
-        "    %shell rm -rf /opt/conda\n",
-        "    %shell wget -q -P /tmp \\\n",
-        "      https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \\\n",
-        "        && bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda \\\n",
-        "        && rm /tmp/Miniconda3-latest-Linux-x86_64.sh\n",
-        "\n",
-        "    PATH=%env PATH\n",
-        "    %env PATH=/opt/conda/bin:{PATH}\n",
-        "\n",
         "    # Install the required versions of all dependencies.\n",
-        "    %shell conda install -y -q conda==4.13.0\n",
-        "    %shell conda install -y -q -c conda-forge -c bioconda \\\n",
+        "    %shell mamba install -y -q -c conda-forge -c bioconda \\\n",
         "      kalign2=2.04 \\\n",
         "      hhsuite=3.3.0 \\\n",
         "      python={python_version} \\\n",
@@ -134,7 +129,7 @@
         "      2>&1 1>/dev/null\n",
         "    %shell pip install -q \\\n",
         "      ml-collections==0.1.0 \\\n",
-        "      PyYAML==5.4.1 \\\n",
+        "      PyYAML==5.3.1 \\\n",
         "      biopython==1.79 \\\n",
         "      modelcif==0.7\n",
         "\n",
@@ -154,16 +149,16 @@
         "except subprocess.CalledProcessError as captured:\n",
         "  print(captured)\n",
         "  raise"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "VzJ5iMjTtoZw",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "VzJ5iMjTtoZw"
       },
+      "outputs": [],
       "source": [
         "#@title Install OpenFold\n",
         "#@markdown Please execute this cell by pressing the *Play* button on \n",
@@ -205,12 +200,16 @@
         "except subprocess.CalledProcessError as captured:\n",
         "  print(captured)\n",
         "  raise"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "_FpxxMo-mvcP"
+      },
+      "outputs": [],
       "source": [
         "#@title Import Python packages\n",
         "#@markdown Please execute this cell by pressing the *Play* button on \n",
@@ -280,13 +279,7 @@
         "from IPython import display\n",
         "from ipywidgets import GridspecLayout\n",
         "from ipywidgets import Output"
-      ],
-      "metadata": {
-        "id": "_FpxxMo-mvcP",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -301,10 +294,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "2tTeTTsLKPjB",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "2tTeTTsLKPjB"
       },
+      "outputs": [],
       "source": [
         "#@title Search against genetic databases\n",
         "\n",
@@ -420,16 +415,16 @@
         "plt.ylabel('Non-Gap Count')\n",
         "plt.yticks(range(0, num_alignments + 1, max(1, int(num_alignments / 3))))\n",
         "plt.show()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "XUo6foMQxwS2",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "XUo6foMQxwS2"
       },
+      "outputs": [],
       "source": [
         "#@title Run OpenFold and download prediction\n",
         "\n",
@@ -693,9 +688,7 @@
         "# --- Download the predictions ---\n",
         "shutil.make_archive(base_name='prediction', format='zip', root_dir=output_dir)\n",
         "files.download(f'{output_dir}.zip')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -789,5 +782,22 @@
         "* BFD: (modified), by Steinegger M. and Söding J., modified by DeepMind, available under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by/4.0/). See the Methods section of the [AlphaFold proteome paper](https://www.nature.com/articles/s41586-021-03828-1) for details."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "OpenFold.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
This fixes #344 (Likely due to Colab updating and breaking something)

It uses condacolab to install mamba which speeds things up dramatically.
It also downgrades PyYAML from 5.4.1 to 5.3.1 because of this issue: https://github.com/yaml/pyyaml/issues/724