### PR TITLE
Fix typo in README.md for hh-suite install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ python3 setup.py install
 To install the HH-suite to `/usr/bin`, run
 
 ```bash
-# scripts/install_hh_suite.sh
+scripts/install_hh_suite.sh
 ```
 
 ## Usage


### PR DESCRIPTION
Fix minor typo for hh-suite install script command:

`# scripts/install_hh_suite.sh` to `scripts/install_hh_suite.sh`