### PR TITLE
Change test_compare_model in deepspeed test to use mean instead of max

### DIFF
--- a/tests/test_deepspeed_evo_attention.py
+++ b/tests/test_deepspeed_evo_attention.py
@@ -274,7 +274,7 @@ class TestDeepSpeedKernel(unittest.TestCase):
         Run full model with and without using DeepSpeed Evoformer attention kernel
         and compare output coordinates.
         """
-        eps = 0.5
+        eps = 0.2
         with open("tests/test_data/sample_feats.pickle", "rb") as fp:
             batch = pickle.load(fp)
 
@@ -316,7 +316,7 @@ class TestDeepSpeedKernel(unittest.TestCase):
                 out_repro = out_repro["sm"]["positions"][-1].squeeze(0)
                 out_repro_ds = out_repro_ds["sm"]["positions"][-1].squeeze(0)
 
-                err = torch.max(torch.abs(out_repro - out_repro_ds))
+                err = torch.mean(torch.abs(out_repro - out_repro_ds))
                 self.assertTrue(err < eps, f'Error: {err}')
 
 


### PR DESCRIPTION
This test was flaky due to the large range of the difference in error (~0.2 - 1.3).

Using a mean difference instead will have a smaller range (0.05 - 0.15), and make the test less flaky.