### PR TITLE
Fix Miniforge3 download link in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 
 RUN apt-get update && apt-get install -y wget libxml2 cuda-minimal-build-11-3 libcusparse-dev-11-3 libcublas-dev-11-3 libcusolver-dev-11-3 git
 RUN wget -P /tmp \
-    "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh" \
+    "https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Miniforge3-Linux-x86_64.sh" \
     && bash /tmp/Miniforge3-Linux-x86_64.sh -b -p /opt/conda \
     && rm /tmp/Miniforge3-Linux-x86_64.sh
 ENV PATH /opt/conda/bin:$PATH


### PR DESCRIPTION
I have modified the Miniforge3 download link in the Dockerfile from the latest one to a specific version. It fixes [this issue](https://github.com/aqlaboratory/openfold/issues/400).

The issue is similar to [this one](https://github.com/conda-forge/miniforge/issues/545), basically caused by an inconsistency of Python version between the base environment (now becomes `3.10` due to the update of the latest Miniforge3) and what's required in `environment.yml` (`3.9`). So I simply tracked [the original commit upon this link](https://github.com/aqlaboratory/openfold/commit/f86d42f40ef14ae1795a007a510ed6d95041dfd1) and replaced it with the exact version at that time.