### PR TITLE
Adds mkl version to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - awscli
   - ml-collections
   - aria2
+  - mkl==2024.0
   - git
   - bioconda::hmmer==3.3.2
   - bioconda::hhsuite==3.3.0


### PR DESCRIPTION
A build error `undefined symbol: iJIT_NotifyEvent` occurs in the package `mkl` version 2024.1, which is a dependency of pytorch. This was observed in the OpenFold repository (Issue #427 ) and in other repositories https://github.com/pytorch/pytorch/issues/123097

Pinning the mkl version fixes this issue.