### PR TITLE
Remove manual -std=c++14 flag for compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ version_dependent_macros = [
 ]
 
 extra_cuda_flags = [
-    '-std=c++14',
     '-maxrregcount=50',
     '-U__CUDA_NO_HALF_OPERATORS__',
     '-U__CUDA_NO_HALF_CONVERSIONS__',


### PR DESCRIPTION
Openfold works with later versions of pytorch, but the newer versions require c++17 for c++ extensions.

This PR removes the manual standard specification and let pytorch do the work. They adds required C++ standard flags if **it is not specified by the users**:

https://github.com/pytorch/pytorch/blob/7a506dd0057ec82f17d72dcf308e2c5eaa4d80f7/torch/utils/cpp_extension.py#L556-L563

This is also true for the pinned version (v1.12).

https://github.com/pytorch/pytorch/blob/664058fa83f1d8eede5d66418abff6e20bd76ca8/torch/utils/cpp_extension.py#L468-L475