### PR TITLE
Fix 3-to-1 letter conversion to use extended mapping

### DIFF
--- a/openfold/data/mmcif_parsing.py
+++ b/openfold/data/mmcif_parsing.py
@@ -283,7 +283,7 @@ def parse(
             author_chain = mmcif_to_author_chain_id[chain_id]
             seq = []
             for monomer in seq_info:
-                code = PDBData.protein_letters_3to1.get(monomer.id, "X")
+                code = PDBData.protein_letters_3to1_extended.get(monomer.id, "X")
                 seq.append(code if len(code) == 1 else "X")
             seq = "".join(seq)
             author_chain_to_sequence[author_chain] = seq


### PR DESCRIPTION
In commit 02cb771 `SCOPData.protein_letters_3to1` got changed to `PDBData.protein_letters_3to1` due to deprecation of `SCOPData` in newer Biopython versions. However, compared to the previous `SCOPData` mapping, `PDBData.protein_letters_3to1` [is very minimal](https://github.com/biopython/biopython/blob/0f41262c84369ed6244d973ca2e893af35e4d387/Bio/Data/PDBData.py) and does not contain any non-standard amino acid conversions which will map all modified residues to `"X"`. Instead, `PDBData.protein_letters_3to1_extended` should come closer to the original functionality.