### PR TITLE
Fix pl_upgrades environment (numpy, cuda, gcc)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,8 @@ channels:
   - pytorch
   - nvidia 
 dependencies:
+  - cuda
+  - gcc=12.4
   - python=3.10
   - libgcc=7.2
   - setuptools=59.5.0
@@ -13,7 +15,7 @@ dependencies:
   - pdbfixer
   - pytorch-lightning
   - biopython
-  - numpy
+  - numpy<2.0.0
   - pandas
   - PyYAML==5.4.1
   - requests


### PR DESCRIPTION
Fix versions to make pl_upgrades usable again:
* avoid numpy 2
* use own cuda tools with proper explicit gcc version

Should fix #494 and #477 and likely few other issues (see below, the list seems long).