### PR TITLE
docs: Add env var instructions to install guide  

### DIFF
--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -20,8 +20,10 @@ At this time, only Linux systems are supported.
     - Activate the environment, e.g `conda activate openfold_env`
 1. Run the setup script to configure kernels and folding resources.
 	> scripts/install_third_party_dependencies.sh`
-1. Prepend the conda environment to the `$LD_LIBRARY_PATH`., e.g. 
-		`export $LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH`. You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
+1. Prepend the conda environment to the `$LD_LIBRARY_PATH` and `$LIBRARY_PATH`.
+	> export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+	> export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
+	- You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
 1. Download parameters. We recommend using a destination as `openfold/resources` as our unittests will look for the weights there.
 	-  For AlphaFold2 weights, use 
 		> ./scripts/download_alphafold_params.sh <dest>


### PR DESCRIPTION
The current documentation is missing instructions about setting the `LIBRARY_PATH` environment variable which is required for tests to pass. 

Specifically `export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH` needs to be done, otherwise a `cannot find -lcurand: No such file or directory` error will occur when running the tests 