### PR TITLE
fix: set numpy and deepspeed dependency versions 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pdbfixer
   - pytorch-lightning
   - biopython
-  - numpy
+  - numpy==1.26.4
   - pandas
   - PyYAML==5.4.1
   - requests
@@ -33,7 +33,7 @@ dependencies:
   - pytorch::pytorch=2.1
   - pytorch::pytorch-cuda=12.1
   - pip:
-      - deepspeed==0.12.4
+      - deepspeed==0.14.5
       - dm-tree==0.1.6
       - git+https://github.com/NVIDIA/dllogger.git
       - flash-attn 


### PR DESCRIPTION
The version of deepspeed specified in environment.yml will lead to a `module 'deepspeed' has no attribute 'comm'` error, so we need to upgrade it. The latest numpy version will lead to `Could not infer dtype of numpy.int32` error, so I downgraded it. This lets all of the tests pass 