### PR TITLE
docs: Add env var to install guide 

### DIFF
--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -20,12 +20,14 @@ At this time, only Linux systems are supported.
     - Activate the environment, e.g `conda activate openfold_env`
 1. Run the setup script to configure kernels and folding resources.
 	> scripts/install_third_party_dependencies.sh`
-1. Prepend the conda environment to the `$LD_LIBRARY_PATH` and `LIBRARY_PATH., e.g. 
+1. Prepend the conda environment to the `$LD_LIBRARY_PATH` and `$LIBRARY_PATH`., e.g. 
 
-	> export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
-	> export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
-	
-		`export $LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH`. You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
+	```
+	export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
+	export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+	```
+
+		You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
 1. Download parameters. We recommend using a destination as `openfold/resources` as our unittests will look for the weights there.
 	-  For AlphaFold2 weights, use 
 		> ./scripts/download_alphafold_params.sh <dest>

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -4,7 +4,7 @@ In this guide, we will OpenFold and its dependencies.
 
 **Pre-requisites**
 
-This package is currently supported for CUDA 11 and Pytorch 1.12. All dependencies are listed in the [`environment.yml`](https://github.com/aqlaboratory/openfold/blob/main/environment.yml)
+This package is currently supported for CUDA 11 and Pytorch 1.12. All dependencies are listed in the [`environment.yml`](https://github.com/aqlaboratory/openfold/blob/main/environment.yml). To install OpenFold for CUDA 12, please refer to the [Environment specific modifications](#Environment-specific-modifications) section.
 
 At this time, only Linux systems are supported.
 
@@ -20,8 +20,12 @@ At this time, only Linux systems are supported.
     - Activate the environment, e.g `conda activate openfold_env`
 1. Run the setup script to configure kernels and folding resources.
 	> scripts/install_third_party_dependencies.sh`
-1. Prepend the conda environment to the `$LD_LIBRARY_PATH`., e.g. 
-		`export $LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH`. You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
+1. Prepend the conda environment to the `$LD_LIBRARY_PATH` and `LIBRARY_PATH`., e.g. 
+	```
+	export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
+	export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+	```
+		You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
 1. Download parameters. We recommend using a destination as `openfold/resources` as our unittests will look for the weights there.
 	-  For AlphaFold2 weights, use 
 		> ./scripts/download_alphafold_params.sh <dest>

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -21,6 +21,7 @@ At this time, only Linux systems are supported.
 1. Run the setup script to configure kernels and folding resources.
 	> scripts/install_third_party_dependencies.sh`
 1. Prepend the conda environment to the `$LD_LIBRARY_PATH` and `LIBRARY_PATH`., e.g. 
+
 	```
 	export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
 	export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -27,7 +27,8 @@ At this time, only Linux systems are supported.
 	export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 	```
 
-		You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
+	You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
+
 1. Download parameters. We recommend using a destination as `openfold/resources` as our unittests will look for the weights there.
 	-  For AlphaFold2 weights, use 
 		> ./scripts/download_alphafold_params.sh <dest>

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -25,6 +25,7 @@ At this time, only Linux systems are supported.
 	export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
 	export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 	```
+	
 		You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
 1. Download parameters. We recommend using a destination as `openfold/resources` as our unittests will look for the weights there.
 	-  For AlphaFold2 weights, use 

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -20,14 +20,12 @@ At this time, only Linux systems are supported.
     - Activate the environment, e.g `conda activate openfold_env`
 1. Run the setup script to configure kernels and folding resources.
 	> scripts/install_third_party_dependencies.sh`
-1. Prepend the conda environment to the `$LD_LIBRARY_PATH` and `LIBRARY_PATH`., e.g. 
+1. Prepend the conda environment to the `$LD_LIBRARY_PATH` and `LIBRARY_PATH., e.g. 
 
-	```
-	export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
-	export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
-	```
+	> export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
+	> export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 	
-		You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
+		`export $LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH`. You may optionally set this as a conda environment variable according to the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) to activate each time the environment is used.
 1. Download parameters. We recommend using a destination as `openfold/resources` as our unittests will look for the weights there.
 	-  For AlphaFold2 weights, use 
 		> ./scripts/download_alphafold_params.sh <dest>


### PR DESCRIPTION
The current documentation is missing instructions about setting the `LIBRARY_PATH` environment variable which is required for tests to pass. 

Specifically `export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH` needs to be done, otherwise a `cannot find -lcurand: No such file or directory` error will occur when running the tests 

Redo of #502 

Formatting seems to be good now 👍 

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/385f3db6-0bc4-48f3-ba39-fe75078d6255">
