### PR TITLE
update environment.yml to work w/ flash-attn

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,4 +38,4 @@ dependencies:
       - deepspeed==0.12.4
       - dm-tree==0.1.6
       - git+https://github.com/NVIDIA/dllogger.git
-      - flash-attn 
+      - git+https://github.com/Dao-AILab/flash-attention.git@2f6c6331792dd20002a2e551959e172617a1bfbc


### PR DESCRIPTION
flash-attn removed support for pytorch 2.1, use old commit for compilation to work. Have not tested commits in-between, so there is probably a newer version than this that is compatible