### PR TITLE
Explicitly set reentrant to `False` for torch checkpointing

### DIFF
--- a/openfold/utils/checkpointing.py
+++ b/openfold/utils/checkpointing.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from functools import partial
 import importlib
 from typing import Any, Tuple, List, Callable, Optional
 
@@ -34,7 +35,7 @@ def get_checkpoint_fn():
     if(deepspeed_is_configured):
         checkpoint = deepspeed.checkpointing.checkpoint
     else:
-        checkpoint = torch.utils.checkpoint.checkpoint
+        checkpoint = partial(torch.utils.checkpoint.checkpoint, use_reentrant=False)
 
     return checkpoint
 


### PR DESCRIPTION
## Description
The purpose of this PR is to set up OpenFold to be compatible with torch 2.6 (technically >=2.4), in particular for using `torch.compile` on modules that do activation checkpointing. 

As discussed [here](https://pytorch.org/docs/2.6/checkpoint.html#torch.utils.checkpoint.checkpoint), torch 2.4 and newer require explicitly passing `use_reentrant` to the checkpointing function. Prior to torch 2.4 (e.g. 2.2), `use_reentrant` defaulted to `True`, however we have found that non-reentrant checkpointing works better with DDP and torch.compile. This is surprisingly hard to find documentation for, but seems to match anecdotal experience of others ([ex](https://github.com/pytorch/pytorch/issues/97436#issuecomment-1550288251)). As a result, this change forces `use_reentrant=False`, enabling the use of `torch.compile` with our structure models.

## For Discussion
If maintainers strongly prefer and are concerned about backwards compatibility, we could adapt this PR to have `checkpoint_blocks` take `use_reentrant` as a user-specified kwarg that defaults to `True` and then gets passed to `get_checkpoint_fn`. Let me know!